### PR TITLE
Remove `eshell-exit-success-p' condition

### DIFF
--- a/eshell-did-you-mean.el
+++ b/eshell-did-you-mean.el
@@ -82,7 +82,6 @@ If THRESHOLD is non-nil, use is as the maximum edit distance."
   "\"Did you mean\" filter for eshell OUTPUT.
 Should be added to `eshell-preoutput-filter-functions'."
   (if (and eshell-last-command-name
-           (not (eshell-exit-success-p))
            (string-prefix-p (format "%s: command not found"
                                     eshell-last-command-name)
                             output))


### PR DESCRIPTION
When `eshell-did-you-mean-output-filter` is invoked with "blah: command not found", the variable `eshell-last-command-status` is not yet set, so it is still 0.  Thus, at this point, (eshell-exit-success-p) will return t!  This is why `eshell-did-you-mean-output-filter` does not seem to work on first invocation.