### PR TITLE
Remove "Known issues" from README.md

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,8 +9,3 @@ command not found ("did you mean…" feature) in Eshell.
 #+BEGIN_SRC emacs-lisp
 (eshell-did-you-mean-setup)
 #+END_SRC
-
-** Known issues
-
-eshell-did-you-mean does not work at the first invocation during an Emacs
-session, I can not figure out why, maybe it is a bug of Eshell.


### PR DESCRIPTION
After #2 was merged and picked up by melpa, the issue mentioned in README.md seems to be resolved.  Now `eshell-did-you-mean` will work on first invocation.

Also maybe create a new tag for melpa-stable?